### PR TITLE
add copy and launch url options + update to refactored payjoin-flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bdk_flutter_app
+# payjoin_flutter_demo
 
 A new Flutter project.
 
@@ -15,4 +15,4 @@ For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials, samples, guidance on
 mobile development, and a full API reference.
 
-# bdk-flutter-demo
+# payjoin-flutter-demo

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,11 +3,14 @@ PODS:
     - Flutter
   - Flutter (1.0.0)
   - payjoin_flutter (0.18.0)
+  - url_launcher_ios (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - bdk_flutter (from `.symlinks/plugins/bdk_flutter/ios`)
   - Flutter (from `Flutter`)
   - payjoin_flutter (from `.symlinks/plugins/payjoin_flutter/ios`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 EXTERNAL SOURCES:
   bdk_flutter:
@@ -16,11 +19,14 @@ EXTERNAL SOURCES:
     :path: Flutter
   payjoin_flutter:
     :path: ".symlinks/plugins/payjoin_flutter/ios"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
   bdk_flutter: fb57a7400a7f3f181c5977bcdc2a5ef347ae4e7f
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   payjoin_flutter: 845f79d3e51d45e67842ee5df33ab492a1fd03cb
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 

--- a/lib/managers/payjoin_manager.dart
+++ b/lib/managers/payjoin_manager.dart
@@ -381,12 +381,12 @@ class PayjoinManager {
         txid: selectedUtxo.outpoint.txid.toString(),
         vout: selectedUtxo.outpoint.vout,
       );
-      payjoin.contributeWitnessInput(
+      await payjoin.contributeWitnessInput(
         txo: txoToContribute,
         outpoint: outpointToContribute,
       );
 
-      payjoin.trySubstituteReceiverOutput(
+      await payjoin.trySubstituteReceiverOutput(
           generateScript: () async => receiverWallet
               .getAddress(addressIndex: const bdk.AddressIndex.increase())
               .address
@@ -451,7 +451,7 @@ class PayjoinManager {
         txid: selectedUtxo.outpoint.txid.toString(),
         vout: selectedUtxo.outpoint.vout,
       );
-      payjoin.contributeWitnessInput(
+      await payjoin.contributeWitnessInput(
         txo: txoToContribute,
         outpoint: outpointToContribute,
       );

--- a/lib/managers/payjoin_manager.dart
+++ b/lib/managers/payjoin_manager.dart
@@ -457,7 +457,7 @@ class PayjoinManager {
       );
 
       /* PjUri is generated with pjos=0, so no output substitution is permitted
-      payjoin.trySubstituteReceiverOutput(
+      await payjoin.trySubstituteReceiverOutput(
           generateScript: () async => receiverWallet
               .getAddress(addressIndex: const bdk.AddressIndex.increase())
               .address

--- a/lib/managers/payjoin_manager.dart
+++ b/lib/managers/payjoin_manager.dart
@@ -63,7 +63,7 @@ class PayjoinManager {
 
   Future<pj_uri.Uri> stringToUri(String pj) async {
     try {
-      return await pj_uri.Uri.fromString(pj);
+      return await pj_uri.Uri.fromStr(pj);
     } catch (e) {
       debugPrint(e.toString());
       rethrow;
@@ -123,8 +123,8 @@ class PayjoinManager {
       try {
         // Extract the request and context, keep repeating this too instead of
         //  only the post to get the timeout error
-        final (request, ctx) = await requestContext.extractContextV2(
-          await pj_uri.Url.fromString(payjoinDirectory),
+        final (request, ctx) = await requestContext.extractV2(
+          ohttpProxyUrl: await pj_uri.Url.fromStr(payjoinDirectory),
         );
 
         // Post the request to the server
@@ -190,7 +190,7 @@ class PayjoinManager {
       try {
         // Extract the request and context, keep repeating this too instead of
         //  only the post to get the timeout error
-        final (originalReq, originalCtx) = await session.extractRequest();
+        final (originalReq, originalCtx) = await session.extractReq();
 
         // Post the request to the server
         final originalPsbt = await http.post(
@@ -202,9 +202,9 @@ class PayjoinManager {
         );
 
         // Process the server response
-        final uncheckedProposal = await session.processResponse(
+        final uncheckedProposal = await session.processRes(
           body: originalPsbt.bodyBytes,
-          clientResponse: originalCtx,
+          ctx: originalCtx,
         );
 
         // If a valid unchecked proposal is received, return it
@@ -232,7 +232,7 @@ class PayjoinManager {
       proposal: uncheckedProposal,
       receiverWallet: receiverWallet,
     );
-    final (proposalReq, proposalCtx) = await payjoinProposal.extractV2Request();
+    final (proposalReq, proposalCtx) = await payjoinProposal.extractV2Req();
     final res = await http.post(
       Uri.parse(proposalReq.url.asString()),
       body: proposalReq.body,
@@ -240,7 +240,7 @@ class PayjoinManager {
         'Content-Type': v2ContentType,
       },
     );
-    await payjoinProposal.processResponse(
+    await payjoinProposal.processRes(
       res: res.bodyBytes,
       ohttpContext: proposalCtx,
     );
@@ -260,7 +260,7 @@ class PayjoinManager {
     send.RequestContext reqCtx,
     String proposalPsbt,
   ) async {
-    final (_, ctx) = await reqCtx.extractContextV1();
+    final (_, ctx) = await reqCtx.extractV1();
     final checkedProposal =
         await ctx.processResponse(response: utf8.encode(proposalPsbt));
     debugPrint('Processed Response: $checkedProposal');
@@ -271,8 +271,8 @@ class PayjoinManager {
     send.RequestContext reqCtx,
     String proposalPsbt,
   ) async {
-    final (_, ctx) = await reqCtx.extractContextV2(
-      await pj_uri.Url.fromString(payjoinDirectory),
+    final (_, ctx) = await reqCtx.extractV2(
+      ohttpProxyUrl: await pj_uri.Url.fromStr(payjoinDirectory),
     );
     final checkedProposal =
         await ctx.processResponse(response: utf8.encode(proposalPsbt));
@@ -303,8 +303,8 @@ class PayjoinManager {
     required Network network,
     required int expireAfter,
   }) async {
-    final ohttpRelayUrl = await pj_uri.Url.fromString(ohttpRelay);
-    final payjoinDirectoryUrl = await pj_uri.Url.fromString(payjoinDirectory);
+    final ohttpRelayUrl = await pj_uri.Url.fromStr(ohttpRelay);
+    final payjoinDirectoryUrl = await pj_uri.Url.fromStr(payjoinDirectory);
     pj_uri.OhttpKeys ohttpKeys = await pj_uri.fetchOhttpKeys(
       ohttpRelay: ohttpRelayUrl,
       payjoinDirectory: payjoinDirectoryUrl,
@@ -319,7 +319,7 @@ class PayjoinManager {
       expireAfter: BigInt.from(expireAfter),
     );
 
-    final (req, ctx) = await session.extractRequest();
+    final (req, ctx) = await session.extractReq();
     final response = await http.post(
       Uri.parse(req.url.asString()),
       body: req.body,
@@ -327,9 +327,9 @@ class PayjoinManager {
         'Content-Type': v2ContentType,
       },
     );
-    final activeSession = await session.processResponse(
+    final activeSession = await session.processRes(
       body: response.bodyBytes,
-      clientResponse: ctx,
+      ctx: ctx,
     );
 
     return activeSession;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -204,6 +204,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   freezed_annotation:
     dependency: transitive
     description:
@@ -341,6 +346,14 @@ packages:
       url: "https://github.com/LtbLightning/payjoin-flutter"
     source: git
     version: "0.18.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pub_semver:
     dependency: transitive
     description:
@@ -426,6 +439,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "95d8027db36a0e52caf55680f91e33ea6aa12a3ce608c90b06f4e429a21067ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.5"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: ab360eb661f8879369acac07b6bb3ff09d9471155357da8443fd5d3cf7363811
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   uuid:
     dependency: transitive
     description:
@@ -476,4 +553,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -341,9 +341,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: main
-      resolved-ref: "0d89b4d64ce22663df447d192bc73849dd74e50f"
-      url: "https://github.com/LtbLightning/payjoin-flutter"
+      ref: override-ffi-functions
+      resolved-ref: e9fe95ca335434d787c82d4efda6cba381b9138c
+      url: "https://github.com/kumulynja/payjoin-flutter"
     source: git
     version: "0.18.0"
   plugin_platform_interface:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   http: ^1.2.1
   payjoin_flutter:
     git:
-      url: https://github.com/LtbLightning/payjoin-flutter
-      ref: main
+      url: https://github.com/kumulynja/payjoin-flutter
+      ref: override-ffi-functions
   url_launcher: ^6.3.0
 dev_dependencies:
   flutter_lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     git:
       url: https://github.com/LtbLightning/payjoin-flutter
       ref: main
+  url_launcher: ^6.3.0
 dev_dependencies:
   flutter_lints: ^2.0.0
   flutter_test:


### PR DESCRIPTION
This PR adds `url_launcher` so the mempool page of a transaction can be opened easily to check the payjoin inputs and outputs. The kotlin version needed to be updated for this.
The bottom sheet modal is adapted to be able to pass a link to launch and to set the text to copy different than the text that is shown in the modal.

It also updates to the `payjoin-flutter` package with the latest refactoring of this PR: https://github.com/LtbLightning/payjoin-flutter/pull/30